### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,12 @@
+language: ruby
+
+sudo: false
+
+cache: bundler
+
 rvm:
  - 2.0.0
- - 2.1.0
+ - 2.1
+ - 2.2
+
 script: CODECLIMATE_REPO_TOKEN=20444906a69acdccfdf40c03c7946e9e80242619bdf0e053230bb89cc236f205 bundle exec rspec


### PR DESCRIPTION
A new version of Ruby has come out since we last updated this, so I
added it to our testing matrix. I also changed 2.1.0 to 2.1 so that
2.1.x will be tested instead of specifically 2.1.0.

Specifying language will help Travis do the right things for this
project. Setting `sudo: false` will allow Travis to use the faster
container-based infrastructure [0](http://docs.travis-ci.com/user/workers/container-based-infrastructure/). And `cache: bundler` will enable
Travis to persist the bundler directory between builds, making our
builds faster [1](http://docs.travis-ci.com/user/caching/#Caching-directories-%28Bundler%2C-dependencies%29).
